### PR TITLE
feat: Nokia-style apple and bump cache version

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@
     scoreEl.textContent = '0';
     const mid = Math.floor(STATE.grid/2);
     STATE.snake = [{x:mid-2,y:mid},{x:mid-1,y:mid},{x:mid,y:mid}];
-    placeApple();
+    STATE.apple = { x: Math.floor(STATE.grid/2) + 4, y: Math.floor(STATE.grid/2) };
     draw();
   }
   function placeApple() {
@@ -184,10 +184,12 @@
     }
     ctx.stroke();
 
+    // apple — red square (classic Nokia style)
     const ax = STATE.apple.x*STATE.cell, ay = STATE.apple.y*STATE.cell;
-    const r = Math.floor(STATE.cell*0.42);
-    ctx.fillStyle = '#7fdba7';
-    ctx.beginPath(); ctx.arc(ax + STATE.cell/2, ay + STATE.cell/2, r, 0, Math.PI*2); ctx.fill();
+    const pad = Math.floor(STATE.cell*0.18);
+    const size = STATE.cell - pad*2;
+    ctx.fillStyle = '#ff5252';
+    ctx.fillRect(ax + pad, ay + pad, size, size);
 
     ctx.fillStyle = '#e6e1d5';
     for (let i=0;i<STATE.snake.length;i++){

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 // Offline cache for Snake — Khairu & Amin
-const CACHE = 'snake-ka-v1';
+const CACHE = 'snake-ka-v2';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- render the apple as a classic red square and set the first spawn near center for visibility
- bump the service worker cache version to force clients to refresh assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ae5bbb3c83298e2e5d0a3bc6b973